### PR TITLE
change(esp-wolfssl): allow to enable OCSP support

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -11,4 +11,15 @@ menu "wolfSSL"
         bool "Enable ALPN (Application Layer Protocol Negotiation) in wolfSSL"
         default y
 
+    config WOLFSSL_HAVE_OCSP
+        bool "Enable OCSP (Online Certificate Status Protocol) in wolfSSL"
+        default n
+        help
+            Enables Online Certificate Status Protocol (OCSP) within wolfSSL, which is the modern alternative
+            to maintaining Certificate Revocation Lists (CRLs). Enabling this option will make esp-tls to automatically
+            indicate support for OCSP when connecting as a TLS client. Server that support OCSP will forward the
+            certificate's revocation status to the client and the client will automatically verify the servers certificate
+            status based on the OCSP response forwarded to it.
+            Note: This option enables the OCSP in stapling (v1) mode for the client hence the TLS server needs to support OCSP stapling v1 .
+
 endmenu # wolfSSL

--- a/README.md
+++ b/README.md
@@ -44,6 +44,10 @@ It shows following options
 
     - Enable ALPN ( Application Layer Protocol Negotiation ) in wolfSSL
         - This option is enabled by default for wolfSSL, and can be disabled if not required.
+
+    - Enable OCSP (Online Certificate Status Protocol) in wolfSSL
+        - This options is disabled by default. Enabling it adds support for checking the host's certificate revocation status
+          during the TLS handshake.
 ---
 **NOTE**
  These options are valid for `esp-tls` only if `wolfSSL` is selected as its SSL/TLS Library.

--- a/port/user_settings.h
+++ b/port/user_settings.h
@@ -44,6 +44,11 @@
 
 #define HAVE_SNI
 
+#ifdef CONFIG_WOLFSSL_HAVE_OCSP
+#define HAVE_OCSP
+#define HAVE_CERTIFICATE_STATUS_REQUEST
+#endif
+
 /* do not use wolfssl defined app_main function used to test esp-wolfssl */
 #define NO_MAIN_DRIVER
 


### PR DESCRIPTION
I've added an option (default off) to allow to enable OCSP with esp-wolfssl.
In particular it makes wolfSSL process the OCSP status forwarded in stabling v1 format
during TLS handshake.

See also: https://github.com/espressif/esp-idf/pull/13618 .