### PR TITLE
fix(esp-wolfssl): send SNI and skip OCSP when skip_common_name is set

### DIFF
--- a/port/esp_tls_wolfssl.c
+++ b/port/esp_tls_wolfssl.c
@@ -394,27 +394,21 @@ static esp_err_t set_client_config(const char *hostname, size_t hostlen, esp_tls
     }
 
 #ifdef CONFIG_WOLFSSL_HAVE_OCSP
-    /* OCSP status checking is part of certificate verification. When the caller
-     * opts out of strict (common-name) verification, skip OCSP too so the
-     * relaxed-verification request is not defeated by an OCSP failure.
-     * See esp-idf PR #14684. */
-    if (!cfg->skip_common_name) {
-        int ocsp_options = 0;
+    int ocsp_options = 0;
 #ifdef ESP_TLS_OCSP_CHECKALL
-        ocsp_options |= WOLFSSL_OCSP_CHECKALL;
+    ocsp_options |= WOLFSSL_OCSP_CHECKALL;
 #endif
-        if ((ret = wolfSSL_CTX_EnableOCSP((WOLFSSL_CTX *)tls->priv_ctx, ocsp_options)) != WOLFSSL_SUCCESS) {
-            ESP_LOGE(TAG, "wolfSSL_CTX_EnableOCSP failed, returned %d", ret);
-            return ESP_ERR_WOLFSSL_CTX_SETUP_FAILED;
-        }
-        if ((ret = wolfSSL_CTX_EnableOCSPStapling((WOLFSSL_CTX *)tls->priv_ctx )) != WOLFSSL_SUCCESS) {
-            ESP_LOGE(TAG, "wolfSSL_CTX_EnableOCSPStapling failed, returned %d", ret);
-            return ESP_ERR_WOLFSSL_CTX_SETUP_FAILED;
-        }
-        if ((ret = wolfSSL_UseOCSPStapling((WOLFSSL *)tls->priv_ssl, WOLFSSL_CSR_OCSP, WOLFSSL_CSR_OCSP_USE_NONCE)) != WOLFSSL_SUCCESS) {
-            ESP_LOGE(TAG, "wolfSSL_UseOCSPStapling failed, returned %d", ret);
-            return ESP_ERR_WOLFSSL_SSL_SETUP_FAILED;
-        }
+    if ((ret = wolfSSL_CTX_EnableOCSP((WOLFSSL_CTX *)tls->priv_ctx, ocsp_options)) != WOLFSSL_SUCCESS) {
+        ESP_LOGE(TAG, "wolfSSL_CTX_EnableOCSP failed, returned %d", ret);
+        return ESP_ERR_WOLFSSL_CTX_SETUP_FAILED;
+    }
+    if ((ret = wolfSSL_CTX_EnableOCSPStapling((WOLFSSL_CTX *)tls->priv_ctx )) != WOLFSSL_SUCCESS) {
+        ESP_LOGE(TAG, "wolfSSL_CTX_EnableOCSPStapling failed, returned %d", ret);
+        return ESP_ERR_WOLFSSL_CTX_SETUP_FAILED;
+    }
+    if ((ret = wolfSSL_UseOCSPStapling((WOLFSSL *)tls->priv_ssl, WOLFSSL_CSR_OCSP, WOLFSSL_CSR_OCSP_USE_NONCE)) != WOLFSSL_SUCCESS) {
+        ESP_LOGE(TAG, "wolfSSL_UseOCSPStapling failed, returned %d", ret);
+        return ESP_ERR_WOLFSSL_SSL_SETUP_FAILED;
     }
 #endif /* CONFIG_WOLFSSL_HAVE_OCSP */
 

--- a/port/esp_tls_wolfssl.c
+++ b/port/esp_tls_wolfssl.c
@@ -364,6 +364,17 @@ static esp_err_t set_client_config(const char *hostname, size_t hostlen, esp_tls
             return ESP_ERR_WOLFSSL_SSL_SET_HOSTNAME_FAILED;
         }
         free(use_host);
+    } else {
+        /* skip_common_name only disables hostname *verification* of the peer
+         * certificate; SNI must still be sent so the server presents the
+         * certificate for the requested host (e.g. virtual hosts / CDNs).
+         * See esp-idf PR #14684. */
+        if (hostname != NULL && hostlen > 0) {
+            if ((ret = wolfSSL_UseSNI(tls->priv_ssl, WOLFSSL_SNI_HOST_NAME, hostname, hostlen)) != WOLFSSL_SUCCESS) {
+                ESP_LOGE(TAG, "wolfSSL_UseSNI failed, returned %d", ret);
+                return ESP_ERR_WOLFSSL_SSL_SET_HOSTNAME_FAILED;
+            }
+        }
     }
 
     if (cfg->alpn_protos) {
@@ -383,21 +394,27 @@ static esp_err_t set_client_config(const char *hostname, size_t hostlen, esp_tls
     }
 
 #ifdef CONFIG_WOLFSSL_HAVE_OCSP
-    int ocsp_options = 0;
+    /* OCSP status checking is part of certificate verification. When the caller
+     * opts out of strict (common-name) verification, skip OCSP too so the
+     * relaxed-verification request is not defeated by an OCSP failure.
+     * See esp-idf PR #14684. */
+    if (!cfg->skip_common_name) {
+        int ocsp_options = 0;
 #ifdef ESP_TLS_OCSP_CHECKALL
-    ocsp_options |= WOLFSSL_OCSP_CHECKALL;
+        ocsp_options |= WOLFSSL_OCSP_CHECKALL;
 #endif
-    if ((ret = wolfSSL_CTX_EnableOCSP((WOLFSSL_CTX *)tls->priv_ctx, ocsp_options)) != WOLFSSL_SUCCESS) {
-        ESP_LOGE(TAG, "wolfSSL_CTX_EnableOCSP failed, returned %d", ret);
-        return ESP_ERR_WOLFSSL_CTX_SETUP_FAILED;
-    }
-    if ((ret = wolfSSL_CTX_EnableOCSPStapling((WOLFSSL_CTX *)tls->priv_ctx )) != WOLFSSL_SUCCESS) {
-        ESP_LOGE(TAG, "wolfSSL_CTX_EnableOCSPStapling failed, returned %d", ret);
-        return ESP_ERR_WOLFSSL_CTX_SETUP_FAILED;
-    }
-    if ((ret = wolfSSL_UseOCSPStapling((WOLFSSL *)tls->priv_ssl, WOLFSSL_CSR_OCSP, WOLFSSL_CSR_OCSP_USE_NONCE)) != WOLFSSL_SUCCESS) {
-        ESP_LOGE(TAG, "wolfSSL_UseOCSPStapling failed, returned %d", ret);
-        return ESP_ERR_WOLFSSL_SSL_SETUP_FAILED;
+        if ((ret = wolfSSL_CTX_EnableOCSP((WOLFSSL_CTX *)tls->priv_ctx, ocsp_options)) != WOLFSSL_SUCCESS) {
+            ESP_LOGE(TAG, "wolfSSL_CTX_EnableOCSP failed, returned %d", ret);
+            return ESP_ERR_WOLFSSL_CTX_SETUP_FAILED;
+        }
+        if ((ret = wolfSSL_CTX_EnableOCSPStapling((WOLFSSL_CTX *)tls->priv_ctx )) != WOLFSSL_SUCCESS) {
+            ESP_LOGE(TAG, "wolfSSL_CTX_EnableOCSPStapling failed, returned %d", ret);
+            return ESP_ERR_WOLFSSL_CTX_SETUP_FAILED;
+        }
+        if ((ret = wolfSSL_UseOCSPStapling((WOLFSSL *)tls->priv_ssl, WOLFSSL_CSR_OCSP, WOLFSSL_CSR_OCSP_USE_NONCE)) != WOLFSSL_SUCCESS) {
+            ESP_LOGE(TAG, "wolfSSL_UseOCSPStapling failed, returned %d", ret);
+            return ESP_ERR_WOLFSSL_SSL_SETUP_FAILED;
+        }
     }
 #endif /* CONFIG_WOLFSSL_HAVE_OCSP */
 


### PR DESCRIPTION
## Background
Migrated from esp-idf PR [#14684](https://github.com/espressif/esp-idf/pull/14684), which proposed two behaviour changes to the wolfSSL backend for `esp_tls_cfg_t.skip_common_name`. After review, **only the SNI change is kept; the OCSP change is dropped.**

## ✅ Kept: send SNI even when `skip_common_name` is set
**What:** when `skip_common_name = true`, still send the SNI extension (the server hostname) so the server returns the certificate for the requested host.

**Why it's correct:**
- SNI (Server Name Indication) is about **certificate selection** — it tells the server which cert to present (needed for virtual hosts / CDNs). Hostname **verification** (CN/SAN matching) is a separate, later step. They are independent.
  - SNI: RFC 6066 §3 — https://datatracker.ietf.org/doc/html/rfc6066#section-3
  - Hostname verification: RFC 6125 — https://datatracker.ietf.org/doc/html/rfc6125
- Standard TLS clients send SNI **regardless of whether hostname verification is relaxed**:
  - `curl -k`/`--insecure` still sends SNI based on the URL host.
  - OpenSSL keeps the two separate: `SSL_set_tlsext_host_name()` (SNI) vs `X509_VERIFY_PARAM_set1_host()` (verification) — https://docs.openssl.org/master/man3/SSL_set_tlsext_host_name/
- wolfSSL exposes them as separate calls too (`wolfSSL_UseSNI()` vs `wolfSSL_check_domain_name()`), so we can send SNI without doing the CN check.

**⚠️ Note — differs from mbedTLS.** ESP-TLS docs say `skip_common_name` disables SNI too ([esp_tls.h L201-208](https://github.com/espressif/esp-idf/blob/4288cd33349c79a14a392ecf72f3dffcd52f64f5/components/esp-tls/esp_tls.h#L201-L208)); this PR keeps SNI on for wolfSSL, so the two backends differ here — an intentional, standards-aligned choice.

## ❌ Dropped: skipping OCSP when `skip_common_name` is set
The original PR also disabled OCSP status checking when `skip_common_name` is set, reasoning that "OCSP checks cannot succeed when the server's domain name does not match its certificate's CN." **That reasoning does not hold at the protocol level**, so the change is dropped:
- An OCSP request identifies the certificate solely by **issuer name hash + issuer key hash + serial number** (`CertID`), with **no reference to the server hostname/CN**.
  - RFC 6960 §4.1.1 — https://datatracker.ietf.org/doc/html/rfc6960#section-4.1.1
- Therefore OCSP revocation status is independent of CN/SAN matching; an OCSP "good" response is returned regardless of whether the CN matches the connection hostname.
- OCSP stays governed solely by `CONFIG_WOLFSSL_HAVE_OCSP` (off by default). Apps that don't want OCSP simply leave it disabled.

## Net change
A single hunk in `port/esp_tls_wolfssl.c`: when `skip_common_name` is set, send SNI (with a NULL/length guard) instead of skipping the whole block. OCSP behaviour is unchanged from upstream.
