### PR TITLE
feat(esp-wolfssl): add wolfSSL certificate bundle support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,14 @@ set(COMPONENT_SRCDIRS "wolfssl/src/"
                       "port"
                       )
 
+# Certificate-bundle support (wolfSSL equivalent of MBEDTLS_CERTIFICATE_BUNDLE).
+# The implementation ships in the wolfSSL submodule's Espressif port; compile it
+# only when the feature is enabled.
+set(WOLFSSL_CRT_BUNDLE_DIR "wolfssl/wolfcrypt/src/port/Espressif/esp_crt_bundle")
+if(CONFIG_WOLFSSL_CERTIFICATE_BUNDLE)
+    list(APPEND COMPONENT_SRCDIRS "${WOLFSSL_CRT_BUNDLE_DIR}")
+endif()
+
 set(COMPONENT_REQUIRES lwip)
 # esp_system: ESP_SYSTEM_INIT_FN auto-registration; esp_hw_support: esp_fill_random()
 # used by esp_wolfssl_seed.c (wc_GenerateSeed).
@@ -64,6 +72,37 @@ endif()
 # Validated against ESP-IDF master (v6.2-dev).
 idf_component_get_property(esp_tls_dir esp-tls COMPONENT_DIR)
 target_include_directories(${COMPONENT_LIB} PRIVATE "${esp_tls_dir}/private_include")
+
+# Generate and embed the trusted-root certificate bundle for wolfSSL.
+# gen_crt_bundle.py writes a fixed file 'x509_crt_bundle_wolfssl' into its
+# working directory; target_add_binary_data() then embeds it, producing the
+# _binary_x509_crt_bundle_wolfssl_start/end symbols that esp_crt_bundle.c uses.
+if(CONFIG_WOLFSSL_CERTIFICATE_BUNDLE)
+    idf_build_get_property(python PYTHON)
+    set(crt_bundle_gen_dir "${COMPONENT_DIR}/${WOLFSSL_CRT_BUNDLE_DIR}")
+    set(crt_bundle_out "${CMAKE_CURRENT_BINARY_DIR}/x509_crt_bundle_wolfssl")
+    set(crt_inputs "${crt_bundle_gen_dir}/cacrt_all.pem" "${crt_bundle_gen_dir}/cacrt_local.pem")
+    add_custom_command(OUTPUT "${crt_bundle_out}"
+        COMMAND ${python} "${crt_bundle_gen_dir}/gen_crt_bundle.py" -q --input ${crt_inputs}
+        WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"
+        DEPENDS ${crt_inputs} "${crt_bundle_gen_dir}/gen_crt_bundle.py"
+        VERBATIM)
+    add_custom_target(wolfssl_crt_bundle DEPENDS "${crt_bundle_out}")
+    add_dependencies(${COMPONENT_LIB} wolfssl_crt_bundle)
+    target_add_binary_data(${COMPONENT_LIB} "${crt_bundle_out}" BINARY)
+    # esp_crt_bundle.c gates its whole implementation behind the legacy
+    # built-in-backend macro CONFIG_ESP_TLS_USING_WOLFSSL. In the custom-stack
+    # model that macro is never set, so define it just for this file to enable
+    # the bundle code (it is the wolfSSL backend here regardless).
+    # esp_crt_bundle.c does not include settings.h first, so WOLFSSL_ESPIDF
+    # (defined via user_settings.h) is not set when its top-level guard is
+    # evaluated and the whole file compiles to nothing. Force settings.h first,
+    # matching every other wolfSSL source.
+    set_source_files_properties("${WOLFSSL_CRT_BUNDLE_DIR}/esp_crt_bundle.c"
+        PROPERTIES
+        COMPILE_DEFINITIONS "CONFIG_ESP_TLS_USING_WOLFSSL=1"
+        COMPILE_FLAGS "-include wolfssl/wolfcrypt/settings.h")
+endif()
 
 target_compile_options(${COMPONENT_LIB} PRIVATE -Wno-cpp -Wno-maybe-uninitialized)
 set_source_files_properties(wolfssl/src/ssl.c PROPERTIES COMPILE_FLAGS "-Wno-format-truncation -Wno-char-subscripts")

--- a/Kconfig
+++ b/Kconfig
@@ -40,4 +40,41 @@ menu "wolfSSL"
             requirements than classical crypto; consider increasing the task
             stack sizes when using them.
 
+    config WOLFSSL_CERTIFICATE_BUNDLE
+        bool "Enable trusted root certificate bundle (wolfSSL)"
+        default n
+        depends on !MBEDTLS_CERTIFICATE_BUNDLE
+        help
+            Enable support for a bundle of trusted root certificates, attached
+            via esp_tls_cfg_t.crt_bundle_attach = esp_crt_bundle_attach. This is
+            the wolfSSL equivalent of CONFIG_MBEDTLS_CERTIFICATE_BUNDLE: the
+            common root CAs are embedded in the app so TLS servers can be
+            verified without supplying a CA certificate per connection.
+
+            Mutually exclusive with CONFIG_MBEDTLS_CERTIFICATE_BUNDLE (wolfSSL
+            forbids enabling both); disable the mbedTLS bundle to use this one.
+
+    choice WOLFSSL_CERTIFICATE_BUNDLE_DEFAULT
+        prompt "Default certificate bundle options"
+        depends on WOLFSSL_CERTIFICATE_BUNDLE
+        default WOLFSSL_CERTIFICATE_BUNDLE_DEFAULT_FULL
+        help
+            Choose which certificates to embed in the default bundle.
+
+        config WOLFSSL_CERTIFICATE_BUNDLE_DEFAULT_FULL
+            bool "Use the full default certificate bundle"
+        config WOLFSSL_CERTIFICATE_BUNDLE_DEFAULT_NONE
+            bool "Do not use the default certificate bundle"
+    endchoice
+
+    config WOLFSSL_CERTIFICATE_BUNDLE_MAX_CERTS
+        int "Maximum number of certificates in the certificate bundle"
+        depends on WOLFSSL_CERTIFICATE_BUNDLE
+        default 200
+
+    config WOLFSSL_DEBUG_CERT_BUNDLE
+        bool "Enable certificate bundle debug logging"
+        depends on WOLFSSL_CERTIFICATE_BUNDLE
+        default n
+
 endmenu # wolfSSL

--- a/port/esp_tls_wolfssl.c
+++ b/port/esp_tls_wolfssl.c
@@ -27,6 +27,9 @@
 
 #include "wolfssl/ssl.h"
 #include "wolfssl/wolfcrypt/settings.h"
+#ifdef CONFIG_WOLFSSL_CERTIFICATE_BUNDLE
+#include "wolfssl/wolfcrypt/port/Espressif/esp_crt_bundle.h"
+#endif
 
 /* wolfSSL-specific error codes (not in esp_tls_errors.h for custom stack).
  * Offset 0x100 is far above the mbedTLS codes in esp_tls_errors.h (<= 0x1D),
@@ -250,14 +253,24 @@ static esp_err_t set_client_config(const char *hostname, size_t hostlen, esp_tls
     }
 
     if (cfg->crt_bundle_attach != NULL) {
-        /* The IDF certificate bundle is mbedTLS-specific (mbedtls parsing
-         * callbacks + bundle format), so it cannot be attached to wolfSSL. */
-        ESP_LOGE(TAG, "crt_bundle_attach is not supported by the wolfSSL backend; "
-                      "use cacert_buf or esp_tls_set_global_ca_store() instead");
+#ifdef CONFIG_WOLFSSL_CERTIFICATE_BUNDLE
+        /* Hand our WOLFSSL_CTX to the bundle, which installs a verify callback
+         * (WOLFSSL_VERIFY_PEER) that checks the peer chain against the embedded
+         * root-CA bundle. */
+        wolfssl_ssl_config bundle_conf = { 0 };
+        bundle_conf.priv_ctx = tls->priv_ctx;
+        bundle_conf.priv_ssl = tls->priv_ssl;
+        esp_err_t bundle_ret = cfg->crt_bundle_attach(&bundle_conf);
+        if (bundle_ret != ESP_OK) {
+            ESP_LOGE(TAG, "Failed to attach certificate bundle, error: 0x%x", bundle_ret);
+            return ESP_ERR_WOLFSSL_CERT_VERIFY_SETUP_FAILED;
+        }
+#else
+        ESP_LOGE(TAG, "crt_bundle_attach is set but CONFIG_WOLFSSL_CERTIFICATE_BUNDLE "
+                      "is disabled; enable it or use cacert_buf / global CA store");
         return ESP_ERR_NOT_SUPPORTED;
-    }
-
-    if (cfg->use_global_ca_store == true) {
+#endif
+    } else if (cfg->use_global_ca_store == true) {
         if (global_cacert == NULL) {
             ESP_LOGE(TAG, "global_ca_store requested but not set; call esp_tls_set_global_ca_store() first");
             return ESP_ERR_INVALID_STATE;

--- a/port/user_settings.h
+++ b/port/user_settings.h
@@ -62,6 +62,13 @@
 /* Allow unknown/undecoded X509v3 extensions - needed for modern CA certs */
 #define WOLFSSL_ALLOW_UNDECODED_EXTENSIONS
 
+#ifdef CONFIG_WOLFSSL_CERTIFICATE_BUNDLE
+/* The trusted-root bundle contains some legacy CAs with a zero serial number,
+ * which wolfSSL's strict (RFC 5280) ASN parsing rejects. Allow them so the
+ * full bundle loads instead of silently dropping those roots. */
+#define WOLFSSL_ASN_ALLOW_0_SERIAL
+#endif
+
 /* TLS 1.3                                 */
 // #define WOLFSSL_TLS13
 #define HAVE_TLS_EXTENSIONS


### PR DESCRIPTION
## What the original esp-idf PRs did
The wolfSSL cert-bundle series in ESP-IDF added the wolfSSL equivalent of the mbedTLS certificate bundle:
- [#16145](https://github.com/espressif/esp-idf/pull/16145) — umbrella "Improve support for wolfssl" (the cert-bundle feature across esp-tls).
- [#17683](https://github.com/espressif/esp-idf/pull/17683) — esp-tls `Kconfig` + `CMakeLists` for the wolfSSL bundle.

They targeted the old built-in wolfSSL backend (`CONFIG_ESP_TLS_USING_WOLFSSL`), which no longer exists in ESP-IDF (wolfSSL now lives here as the esp-tls custom stack).

## What this PR does
Re-implements the feature for the custom-stack model:
- **Kconfig** — `WOLFSSL_CERTIFICATE_BUNDLE` (+ default FULL/NONE, max-certs, debug). Mutually exclusive with `MBEDTLS_CERTIFICATE_BUNDLE` (wolfSSL forbids both at once).
- **CMakeLists** — compiles the wolfSSL `esp_crt_bundle.c` port and generates + embeds the CA blob (`gen_crt_bundle.py` → `_binary_x509_crt_bundle_wolfssl_*`). That file is gated on the legacy `CONFIG_ESP_TLS_USING_WOLFSSL` and needs `settings.h` first, so both are forced for that single source.
- **esp_tls_wolfssl.c** — wires `crt_bundle_attach` into the custom stack by handing our `WOLFSSL_CTX` to the bundle (installs a `WOLFSSL_VERIFY_PEER` callback). The `ESP_ERR_NOT_SUPPORTED` path stays when the feature is off.
- **user_settings.h** — allows zero-serial CAs (`WOLFSSL_ASN_ALLOW_0_SERIAL`) when the bundle is enabled, so legacy roots are not dropped.

Usage (unchanged from mbedTLS): `esp_tls_cfg_t cfg = { .crt_bundle_attach = esp_crt_bundle_attach };`

## Testing
- **ESP32-C5**: a client using only the embedded bundle (no explicit CA) completes a TLS handshake to `www.howsmyssl.com` (PASS); after allowing zero-serial CAs the full bundle loads with no parse errors.
- Default build (bundle disabled) still compiles cleanly — the feature is fully gated.
