### PR TITLE
esp-wolfssl: esp_key_config_t server key support, ESP-IDF <6.0 build fix, and ESP_TLS_HAS_WOLFSSL macro

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,6 +42,14 @@ set(COMPONENT_SRCEXCLUDE_1
     "wolfssl/wolfcrypt/src/ext_xmss.c"
     )
 
+# port/esp_tls_wolfssl.c integrates wolfSSL as an esp-tls "custom stack", which
+# relies on esp_tls_custom_stack.h -- a header that only exists in ESP-IDF >= 6.0.
+# On older IDF that header is absent, so exclude the file there; the component
+# still builds and is usable via the native wolfSSL API (see examples/wolfssl_client).
+if(NOT CONFIG_ESP_TLS_CUSTOM_STACK)
+    list(APPEND COMPONENT_SRCEXCLUDE_1 "port/esp_tls_wolfssl.c")
+endif()
+
 idf_component_register(SRC_DIRS "${COMPONENT_SRCDIRS}"
                         INCLUDE_DIRS "${COMPONENT_ADD_INCLUDEDIRS}"
                         REQUIRES "${COMPONENT_REQUIRES}"

--- a/README.md
+++ b/README.md
@@ -41,28 +41,22 @@ work unchanged. **No code changes are needed in `app_main`; you do not need to
 call `esp_wolfssl_register_stack()` explicitly.**
 
 The only requirement is that the `esp-wolfssl` component must be part of your
-build so that the auto-registration init function gets linked in. The
-recommended way to do that is via the IDF Component Manager:
-
-```bash
-# From the root of your project (the directory that contains main/):
-idf.py add-dependency "espressif/esp-wolfssl^1.0.0"
-```
-
-> Note: until this version of the component is published to the
-> [IDF Component Registry](https://components.espressif.com), use the
-> path-based dependency described below instead.
-
-This creates (or updates) `main/idf_component.yml` with an entry like:
+build so that the auto-registration init function gets linked in. This
+component is not published to the IDF Component Registry, so clone it (see
+[Getting Started](#getting-started)) and add it as a local, path-based
+dependency in your project's `main/idf_component.yml`:
 
 ```yaml
 dependencies:
-  espressif/esp-wolfssl: "^1.0.0"
+  esp-wolfssl:
+    path: /path/to/esp-wolfssl
 ```
 
-The Component Manager then injects `esp-wolfssl` into `main`'s private
-requirements before the build's dependency tree is expanded, so the component
-is pulled in even under `MINIMAL_BUILD` projects without any further wiring.
+Equivalently, vendor the component under `components/esp-wolfssl/` in your
+project, or point `EXTRA_COMPONENT_DIRS` at its location in your top-level
+`CMakeLists.txt`. Either way the Component Manager / build system injects
+`esp-wolfssl` into the build, so it is pulled in even under `MINIMAL_BUILD`
+projects without any further wiring.
 
 Finally, enable the custom stack and (re)build:
 
@@ -76,22 +70,6 @@ idf.py build flash monitor
 
 That's it — `esp-tls` calls now go through wolfSSL.
 
-## Alternative: path-based dependency (in-tree / forks)
-
-If you're working from a fork or vendor the component directly under
-`components/esp-wolfssl/` in your project (e.g. while iterating on changes to
-this repository), use a path-based dependency instead of the registry one. In
-`main/idf_component.yml`:
-
-```yaml
-dependencies:
-  esp-wolfssl:
-    path: ${PROJECT_DIR}/components/esp-wolfssl
-```
-
-The auto-registration mechanism is the same; only the way the component is
-located on disk differs.
-
 ## Verifying
 
 On boot, `esp-tls` logs a single line confirming that the wolfSSL stack
@@ -104,8 +82,7 @@ I (xxx) esp-tls-custom-stack: Custom TLS stack registered successfully
 If you do not see that line and `esp_tls_conn_*` calls return
 `ESP_ERR_INVALID_STATE` / "No TLS stack registered", the `esp-wolfssl`
 component was likely trimmed out of the build — double-check that
-`main/idf_component.yml` lists `esp-wolfssl` (registry or path) as a
-dependency.
+`main/idf_component.yml` lists `esp-wolfssl` (path-based) as a dependency.
 
 # Options (Debugging and more)
 - `esp-wolfssl` options are available under `idf.py menuconfig -> Component Config -> wolfSSL`.
@@ -149,4 +126,3 @@ In general, these are links which will be useful for using both wolfSSL, as well
 - wolfSSL Manual [https://www.wolfssl.com/docs/wolfssl-manual/]()
 - wolfSSL GitHub
  [https://github.com/wolfssl/wolfssl]()
-

--- a/include/esp_wolfssl_stack.h
+++ b/include/esp_wolfssl_stack.h
@@ -16,6 +16,21 @@ extern "C" {
 #if CONFIG_ESP_TLS_CUSTOM_STACK
 
 /**
+ * @brief Indicates that the wolfSSL TLS backend is available in this build.
+ *
+ * Defined whenever this component is part of the build with the ESP-TLS custom
+ * stack enabled (wolfSSL registers itself as that stack). Application code can
+ * `#ifdef ESP_TLS_HAS_WOLFSSL` to feature-detect wolfSSL.
+ *
+ * This mirrors the ESP_TLS_HAS_WOLFSSL macro that ESP-IDF used to define in
+ * esp_tls.h when wolfSSL was a built-in esp-tls backend
+ * (CONFIG_ESP_TLS_USING_WOLFSSL). It is kept under the same name so code that
+ * already feature-detects wolfSSL this way keeps working now that wolfSSL
+ * lives in the esp-wolfssl component.
+ */
+#define ESP_TLS_HAS_WOLFSSL
+
+/**
  * @brief Register wolfSSL as the custom TLS stack for ESP-TLS
  *
  * Calling this function is normally NOT needed: when this component is part

--- a/port/esp_tls_wolfssl.c
+++ b/port/esp_tls_wolfssl.c
@@ -318,19 +318,36 @@ static esp_err_t set_client_config(const char *hostname, size_t hostlen, esp_tls
 #endif
     }
 
-    if (cfg->clientcert_buf != NULL && cfg->clientkey_buf != NULL) {
+    /* Resolve the client private key the same way as the server key above:
+     * prefer the legacy clientkey_buf, but also accept the unified key config
+     * (cfg->client_key), detected via __has_include (see the server path). */
+    const unsigned char *clientkey_buf = cfg->clientkey_buf;
+    unsigned int clientkey_bytes = cfg->clientkey_bytes;
+#if defined(__has_include) && __has_include("esp_key_config.h")
+    if (clientkey_buf == NULL && cfg->client_key != NULL) {
+        if (cfg->client_key->source == ESP_KEY_SOURCE_BUFFER) {
+            clientkey_buf = (const unsigned char *)cfg->client_key->buffer.data;
+            clientkey_bytes = (unsigned int)cfg->client_key->buffer.len;
+        } else {
+            ESP_LOGE(TAG, "Unsupported client_key source %d for wolfSSL backend (only ESP_KEY_SOURCE_BUFFER)", cfg->client_key->source);
+            return ESP_FAIL;
+        }
+    }
+#endif /* __has_include("esp_key_config.h") */
+
+    if (cfg->clientcert_buf != NULL && clientkey_buf != NULL) {
         if ((esp_load_wolfssl_verify_buffer(tls,cfg->clientcert_buf, cfg->clientcert_bytes, FILE_TYPE_SELF_CERT, &ret)) != ESP_OK) {
             ESP_LOGE(TAG, "Error in loading certificate verify buffer, returned %d", ret);
             wolfssl_print_error_msg(ret);
             return ESP_ERR_WOLFSSL_CERT_VERIFY_SETUP_FAILED;
         }
-        if ((esp_load_wolfssl_verify_buffer(tls,cfg->clientkey_buf, cfg->clientkey_bytes, FILE_TYPE_SELF_KEY, &ret)) != ESP_OK) {
+        if ((esp_load_wolfssl_verify_buffer(tls,clientkey_buf, clientkey_bytes, FILE_TYPE_SELF_KEY, &ret)) != ESP_OK) {
             ESP_LOGE(TAG, "Error in loading private key verify buffer, returned %d", ret);
             wolfssl_print_error_msg(ret);
             return ESP_ERR_WOLFSSL_CERT_VERIFY_SETUP_FAILED;
         }
-    } else if (cfg->clientcert_buf != NULL || cfg->clientkey_buf != NULL) {
-        ESP_LOGE(TAG, "You have to provide both clientcert_buf and clientkey_buf for mutual authentication");
+    } else if (cfg->clientcert_buf != NULL || clientkey_buf != NULL) {
+        ESP_LOGE(TAG, "You have to provide both clientcert_buf and a client key (clientkey_buf or client_key) for mutual authentication");
         return ESP_FAIL;
     }
 
@@ -431,19 +448,38 @@ static esp_err_t set_server_config(esp_tls_cfg_server_t *cfg, esp_tls_t *tls)
         wolfSSL_CTX_set_verify( (WOLFSSL_CTX *)tls->priv_ctx, WOLFSSL_VERIFY_NONE, NULL);
     }
 
-    if (cfg->servercert_buf != NULL && cfg->serverkey_buf != NULL) {
+    /* Accept the unified key config (cfg->server_key) as well as the legacy
+     * serverkey_buf. Only the in-memory BUFFER source is supported. The unified
+     * esp_key_config_t interface was added to esp-tls after v6.0, so detect it
+     * by header presence (it is absent on v6.0 and earlier, which only have
+     * serverkey_buf) rather than by IDF version number. */
+    const unsigned char *serverkey_buf = cfg->serverkey_buf;
+    unsigned int serverkey_bytes = cfg->serverkey_bytes;
+#if defined(__has_include) && __has_include("esp_key_config.h")
+    if (serverkey_buf == NULL && cfg->server_key != NULL) {
+        if (cfg->server_key->source == ESP_KEY_SOURCE_BUFFER) {
+            serverkey_buf = (const unsigned char *)cfg->server_key->buffer.data;
+            serverkey_bytes = (unsigned int)cfg->server_key->buffer.len;
+        } else {
+            ESP_LOGE(TAG, "Unsupported server_key source %d for wolfSSL backend (only ESP_KEY_SOURCE_BUFFER)", cfg->server_key->source);
+            return ESP_FAIL;
+        }
+    }
+#endif /* __has_include("esp_key_config.h") */
+
+    if (cfg->servercert_buf != NULL && serverkey_buf != NULL) {
         if ((esp_load_wolfssl_verify_buffer(tls,cfg->servercert_buf, cfg->servercert_bytes, FILE_TYPE_SELF_CERT, &ret)) != ESP_OK) {
             ESP_LOGE(TAG, "Error in loading certificate verify buffer, returned %d", ret);
             wolfssl_print_error_msg(ret);
             return ESP_ERR_WOLFSSL_CERT_VERIFY_SETUP_FAILED;
         }
-        if ((esp_load_wolfssl_verify_buffer(tls,cfg->serverkey_buf, cfg->serverkey_bytes, FILE_TYPE_SELF_KEY, &ret)) != ESP_OK) {
+        if ((esp_load_wolfssl_verify_buffer(tls,serverkey_buf, serverkey_bytes, FILE_TYPE_SELF_KEY, &ret)) != ESP_OK) {
             ESP_LOGE(TAG, "Error in loading private key verify buffer, returned %d", ret);
             wolfssl_print_error_msg(ret);
             return ESP_ERR_WOLFSSL_CERT_VERIFY_SETUP_FAILED;
         }
     } else {
-        ESP_LOGE(TAG, "You have to provide both servercert_buf and serverkey_buf for https_server");
+        ESP_LOGE(TAG, "You have to provide a server certificate (servercert_buf) and key (serverkey_buf or server_key) for https_server");
         return ESP_FAIL;
     }
 


### PR DESCRIPTION
## What

- **`port/esp_tls_wolfssl.c`** — accept the unified `esp_key_config_t` (`cfg->server_key` / `cfg->client_key`) on the esp-tls **server and client** paths, in addition to the legacy `serverkey_buf` / `clientkey_buf`. The unified key interface was added to esp-tls **after v6.0**, so it is detected via `__has_include("esp_key_config.h")` (not an IDF version number) to keep building on v6.0 and earlier.
- **`CMakeLists.txt`** — don't compile `port/esp_tls_wolfssl.c` when `CONFIG_ESP_TLS_CUSTOM_STACK` is unset (it uses the 6.0-only `esp_tls_custom_stack.h`), so the component builds on **ESP-IDF < 6.0** (native-API use).
- **`include/esp_wolfssl_stack.h`** — define **`ESP_TLS_HAS_WOLFSSL`** for feature detection. Migrated from #29 (esp-idf#17682); **supersedes and closes #29**.
- **`README.md`** — document path-based (clone) usage; drop the registry / `add-dependency` instructions.

## Why the code changes

- **key config** — ESP-IDF commit `36090b71611` (*feat(esp-tls): Add unified private key interface via esp_key_config_t*) switched `esp_https_server` / `https_server/simple` to pass the key via `cfg->server_key` instead of `serverkey_buf`. The wolfSSL port only read `serverkey_buf`, so `https_server/simple` failed with `esp-tls-wolfssl: You have to provide both servercert_buf and serverkey_buf`. The client path (`client_key`) had the same gap.
- **`< 6.0` build fix** — `esp_tls_custom_stack.h` exists only in v6.0+, but the custom-stack file was compiled unconditionally, so on v5.5 the build failed with `fatal error: esp_tls_custom_stack.h: No such file or directory`.

## Testing

Backend = esp-wolfssl. On IDF 6.0+ it is the esp-tls **custom stack** (`CONFIG_ESP_TLS_CUSTOM_STACK=y`); on < 6.0 it is used via the **native wolfSSL API** (custom stack does not exist there). Logs attached in the comments below.

| ESP-IDF | Chip | Example | Backend path | Result |
|---|---|---|---|---|
| master (v6.2-dev) | ESP32-C3 | esp-idf `https_request` | custom stack | ✅ TLS 1.2 → HTTP 200 |
| master (v6.2-dev) | ESP32-C3 | esp-idf `https_server/simple` | custom stack (mutual TLS) | ✅ HTTP 200 `Hello Secure World!` |
| master (v6.2-dev) | ESP32-C3 | esp-wolfssl `examples/https_request` | custom stack | ✅ TLS 1.2 → HTTP 200 |
| **v6.0.1** | ESP32 | esp-idf `https_request` | custom stack | ✅ TLS 1.2 → HTTP 200 |
| **v6.0.1** | ESP32 | esp-idf `https_server/simple` | custom stack (mutual TLS) | ✅ HTTP 200 `Hello Secure World!` |
| **v5.5.4** | ESP32-C3 | esp-wolfssl `examples/wolfssl_client` | native wolfSSL API | ✅ TLS → HTTP 200 |

**Builds:** master (v6.2-dev) ✅ · v6.0.1 ✅ · v5.5.4 ✅. On v6.0.1 the `__has_include` guard is also exercised (there `esp_key_config.h` is absent, so `server_key`/`client_key` are correctly excluded); on v5.5.4 the component builds only because `esp_tls_wolfssl.c` is excluded (`< 6.0` fix).
